### PR TITLE
TRD-1467 Migrate samples streamers to StocknoteAPIPythonBridge and bu…

### DIFF
--- a/samples/README.md
+++ b/samples/README.md
@@ -1,10 +1,12 @@
 # SAMCO Trade API v3.2 — Python samples
 
 Runnable Python clients for the v3.2 endpoints documented in
-[`ta-api-docs`](https://docs-tradeapi.samco.in). Most samples are plain
-`requests` / `websocket-client` (no SDK dependency) so they read 1:1
-against the docs; `sample_client.py` is the same flow expressed through
-the published `stocknotebridge` (`snapi_py_client`) SDK.
+[`ta-api-docs`](https://docs-tradeapi.samco.in). REST samples are plain
+`requests` (no SDK dependency) so they read 1:1 against the docs.
+`streaming_quote.py` and `streaming_market_data.py` drive the websocket
+through the published `stocknotebridge` (`snapi_py_client`) SDK
+(>= 3.2.2 — see TRD-1467 streamer fix); `sample_client.py` is the
+full REST + streaming flow expressed through the same SDK.
 
 ## Install
 
@@ -71,8 +73,8 @@ SAMCO_RUN_STREAMING=false
 | `python order_status.py`                 | `GET /order/getOrderStatus`                | `order/get-order-status.md`                 |
 | `python get_positions.py`                | `GET /position/getPositions`               | `positions/get-positions.md`                |
 | `python get_holdings.py`                 | `GET /holding/getHoldings`                 | `holdings/get-holdings.md`                  |
-| `python streaming_quote.py`              | `wss://stream.samco.in` (`quote`)          | `streaming/streaming-quote-data.md`         |
-| `python streaming_market_data.py`        | `wss://stream.samco.in` (`quote2`, depth)  | `streaming/streaming-market-data.md`        |
+| `python streaming_quote.py`              | `wss://stream.samco.in` (`quote`) via SDK  | `streaming/streaming-quote-data.md`         |
+| `python streaming_market_data.py`        | `wss://stream.samco.in` (`quote2`, depth) via SDK | `streaming/streaming-market-data.md`  |
 | `python sample_client.py`                | End-to-end flow via `stocknotebridge` SDK  | (SDK walkthrough)                           |
 | `python quick_start.py`                  | Runs every sample above in sequence        | (mirrors Java `QuickStartSample`)           |
 

--- a/samples/pyproject.toml
+++ b/samples/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "samco-trade-api-samples"
-version = "3.2.1"
+version = "3.2.2"
 description = "Runnable Python samples for the SAMCO Trade API v3.2 endpoints."
 readme = "README.md"
 license = "MIT"

--- a/samples/quick_start.py
+++ b/samples/quick_start.py
@@ -39,17 +39,18 @@ def run_stream(title: str, open_fn, close_fn, duration_s: int) -> None:
     section(title)
     print(f"[{title}] streaming for {duration_s}s …")
     try:
-        ws = open_fn()
+        runner = open_fn()
     except Exception as exc:  # noqa: BLE001
         print(f"[{title}] failed: {type(exc).__name__}: {exc}")
         return
 
-    thread = threading.Thread(target=ws.run_forever, daemon=True)
+    target = getattr(runner, "start_streaming", None) or runner.run_forever
+    thread = threading.Thread(target=target, daemon=True)
     thread.start()
     time.sleep(duration_s)
 
     print(f"[{title}] {duration_s}s elapsed - unsubscribing and closing.")
-    close_fn(ws)
+    close_fn(runner)
     thread.join(timeout=5)
 
 

--- a/samples/streaming_market_data.py
+++ b/samples/streaming_market_data.py
@@ -3,59 +3,37 @@ wss://stream.samco.in   streaming_type: "quote2"
 
 Continuous market-depth stream — 5 levels of bids/asks.
 
+Uses StocknoteAPIPythonBridge (stocknotebridge >= 3.2.2) so the v3.2
+streamer fix (TRD-1467) is exercised.
+
 Reference: https://docs-tradeapi.samco.in/streaming/streaming-market-data
 
 Run: python streaming_market_data.py
 """
 
-import json
 import signal
-import websocket
 
-from config import STREAM_URL, load_env, require_session_token
+from snapi_py_client.snapi_bridge import StocknoteAPIPythonBridge
 
-
-def _build_frame(symbols: list, request_type: str) -> dict:
-    return {
-        "request": {
-            "streaming_type": "quote2",
-            "data": {"symbols": [{"symbol": s} for s in symbols]},
-            "request_type": request_type,
-            "response_format": "json",
-        }
-    }
+from config import load_env, require_session_token
 
 
-def stream_market_data(session_token: str, symbols: list) -> websocket.WebSocketApp:
-    def on_open(ws):
-        print("Connected — sending subscribe frame")
-        ws.send(json.dumps(_build_frame(symbols, "subscribe")))
-
-    def on_message(_ws, msg):
-        print("Market data ::", msg)
-
-    def on_error(_ws, error):
-        print("WS error:", error)
-
-    def on_close(_ws, _code, _reason):
-        print("Connection closed")
-
-    return websocket.WebSocketApp(
-        STREAM_URL,
-        header={"x-session-token": session_token},
-        on_open=on_open,
-        on_message=on_message,
-        on_error=on_error,
-        on_close=on_close,
-    )
+def stream_market_data(session_token: str, symbols: list) -> StocknoteAPIPythonBridge:
+    bridge = StocknoteAPIPythonBridge()
+    bridge.set_session_token(session_token)
+    bridge.set_streaming_data(symbols, StocknoteAPIPythonBridge.STREAMING_TYPE_MARKET_DEPTH)
+    return bridge
 
 
-def close_market_data_stream(ws: websocket.WebSocketApp, symbols: list) -> None:
+def close_market_data_stream(bridge: StocknoteAPIPythonBridge, symbols: list) -> None:
     try:
-        ws.send(json.dumps(_build_frame(symbols, "unsubscribe")))
+        bridge.unsubscribe_market_data(symbols)
     except Exception:
         pass
-    ws.close()
+    try:
+        bridge.ws.close()
+    except Exception:
+        pass
 
 
 def main() -> None:
@@ -63,13 +41,13 @@ def main() -> None:
     token = require_session_token()
 
     symbols = ["3880_NSE", "30125_NSE"]
-    ws_app = stream_market_data(token, symbols)
+    bridge = stream_market_data(token, symbols)
 
     def _sigint(_sig, _frame):
-        close_market_data_stream(ws_app, symbols)
+        close_market_data_stream(bridge, symbols)
 
     signal.signal(signal.SIGINT, _sigint)
-    ws_app.run_forever()
+    bridge.start_streaming()
 
 
 if __name__ == "__main__":

--- a/samples/streaming_quote.py
+++ b/samples/streaming_quote.py
@@ -3,65 +3,42 @@ wss://stream.samco.in   streaming_type: "quote"
 
 Continuous quote stream — LTP, OHLC, OI, top bid/ask, volume.
 
+Uses StocknoteAPIPythonBridge (stocknotebridge >= 3.2.2) so the v3.2
+streamer fix (TRD-1467) is exercised.
+
 Reference: https://docs-tradeapi.samco.in/streaming/streaming-quote-data
 
 Run: python streaming_quote.py
 """
 
-import json
 import signal
-import websocket
 
-from config import STREAM_URL, load_env, require_session_token
+from snapi_py_client.snapi_bridge import StocknoteAPIPythonBridge
 
-
-def _build_frame(symbols: list, request_type: str) -> dict:
-    return {
-        "request": {
-            "streaming_type": "quote",
-            "data": {"symbols": [{"symbol": s} for s in symbols]},
-            "request_type": request_type,
-            "response_format": "json",
-        }
-    }
+from config import load_env, require_session_token
 
 
-def stream_quotes(session_token: str, symbols: list) -> websocket.WebSocketApp:
-    """Open a quote stream and subscribe to `symbols`. Returns the WebSocketApp.
+def stream_quotes(session_token: str, symbols: list) -> StocknoteAPIPythonBridge:
+    """Configure a SnapiBridge for a quote stream subscribing to `symbols`.
 
-    The caller is responsible for driving the loop (e.g. `ws.run_forever()` in
-    a thread) and for calling `close_quote_stream(ws, symbols)` when done.
+    The caller drives the loop with `bridge.start_streaming()` (e.g. in a
+    thread) and calls `close_quote_stream(bridge, symbols)` when done.
     """
-
-    def on_open(ws):
-        print("Connected — sending subscribe frame")
-        ws.send(json.dumps(_build_frame(symbols, "subscribe")))
-
-    def on_message(_ws, msg):
-        print("Quote ::", msg)
-
-    def on_error(_ws, error):
-        print("WS error:", error)
-
-    def on_close(_ws, _code, _reason):
-        print("Connection closed")
-
-    return websocket.WebSocketApp(
-        STREAM_URL,
-        header={"x-session-token": session_token},
-        on_open=on_open,
-        on_message=on_message,
-        on_error=on_error,
-        on_close=on_close,
-    )
+    bridge = StocknoteAPIPythonBridge()
+    bridge.set_session_token(session_token)
+    bridge.set_streaming_data(symbols, StocknoteAPIPythonBridge.STREAMING_TYPE_QUOTE)
+    return bridge
 
 
-def close_quote_stream(ws: websocket.WebSocketApp, symbols: list) -> None:
+def close_quote_stream(bridge: StocknoteAPIPythonBridge, symbols: list) -> None:
     try:
-        ws.send(json.dumps(_build_frame(symbols, "unsubscribe")))
+        bridge.unsubscribe_quote(symbols)
     except Exception:
         pass
-    ws.close()
+    try:
+        bridge.ws.close()
+    except Exception:
+        pass
 
 
 def main() -> None:
@@ -69,13 +46,13 @@ def main() -> None:
     token = require_session_token()
 
     symbols = ["532826_BSE"]
-    ws_app = stream_quotes(token, symbols)
+    bridge = stream_quotes(token, symbols)
 
     def _sigint(_sig, _frame):
-        close_quote_stream(ws_app, symbols)
+        close_quote_stream(bridge, symbols)
 
     signal.signal(signal.SIGINT, _sigint)
-    ws_app.run_forever()
+    bridge.start_streaming()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
…mp samples to 3.2.2

Switch streaming_quote.py and streaming_market_data.py from raw websocket-client to the stocknotebridge SDK (set_streaming_data + start_streaming) so the TRD-1467 streamer fix shipped in stocknotebridge 3.2.2 is exercised. quick_start.py threads the bridge's start_streaming instead of run_forever. README updated to reflect the SDK dependency.